### PR TITLE
Fix paths, wasp dash ports and new line

### DIFF
--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -149,10 +149,9 @@ services:
       hornet:
         condition: service_healthy
     volumes:
-      - ./data/sandboxdb:/app/database
+      - ./data/sandboxdb/indexer:/app/database
     command:
       - "--inx.address=hornet:9029"
-      - "--indexer.db.sqlite.path=database/indexer"
       - "--restAPI.bindAddress=inx-indexer:9091"
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=inx-indexer:9312"
@@ -184,10 +183,9 @@ services:
         soft: 16384
         hard: 16384
     volumes:
-      - ./data/sandboxdb:/app/database
+      - ./data/sandboxdb/participation:/app/database
     command:
       - "--inx.address=hornet:9029"
-      - "--participation.db.path=database/participation"
       - "--restAPI.bindAddress=inx-participation:9892"
 
   inx-spammer:
@@ -233,11 +231,11 @@ services:
       - "traefik.http.routers.hornet-dashboard.entrypoints=web"
       - "traefik.http.services.hornet-dashboard.loadbalancer.server.port=8081"
     volumes:
-      - ./data/sandboxdb:/app/database
+      - ./data/sandboxdb/dashboard:/app/database
     command:
       - "--inx.address=hornet:9029"
       - "--dashboard.bindAddress=inx-dashboard:8081"
-      - "--dashboard.auth.identityFilePath=/app/database/dashboard/identity.key"
+      - "--dashboard.auth.identityFilePath=database/identity.key"
       - "--dashboard.auth.username=${DASHBOARD_USERNAME:-admin}"
       - "--dashboard.auth.passwordHash=${DASHBOARD_PASSWORD:-c4a3fcd2ebec3ac0d105411653284efa9c636e754b9fbbaf58b3adcb974f3655}"
       - "--dashboard.auth.passwordSalt=${DASHBOARD_SALT:-11ed024b8f74191c8484579db15623435c994ae4c28d9ad1b2ad8c1807bf7469}"
@@ -261,11 +259,8 @@ services:
         soft: 16384
         hard: 16384
     volumes:
-      - ./data/sandboxdb/legacy:/app/data/database
+      - ./data/sandboxdb/database_legacy:/app/database
     command:
-      - "--db.tangle.path=data/database/tangle"
-      - "--db.snapshot.path=data/database/snapshot"
-      - "--db.spent.path=data/database/spent"
       - "--inx.enabled=true"
       - "--inx.address=hornet:9029"
       - "--restAPI.bindAddress=inx-api-core-v0:9093"
@@ -287,10 +282,8 @@ services:
         soft: 16384
         hard: 16384
     volumes:
-      - ./data/sandboxdb/database_chrysalis:/app/data/database
+      - ./data/sandboxdb/database_chrysalis:/app/database
     command:
-      - "--db.tangle.path=data/database/tangle"
-      - "--db.utxo.path=data/database/utxo"
       - "--inx.enabled=true"      
       - "--inx.address=hornet:9029"
       - "--restAPI.bindAddress=inx-api-core-v1:9094"
@@ -324,18 +317,10 @@ services:
     ports:
       - "4000:4000/tcp" # Peering
     volumes:
-      - ./data/wasp:/app/waspdb
+      - ./data/sandboxdb/wasp:/app/waspdb
     command:
       - "--logger.level=debug"
       - "--inx.address=hornet:9029"
-      - "--db.chainState.path=/app/waspdb/chains/data"
-      - "--p2p.identity.filePath=/app/waspdb/identity/identity.key"
-      - "--p2p.db.path=/app/waspdb/p2pstore"
-      - "--registries.chains.filePath=/app/waspdb/chains/chain_registry.json"
-      - "--registries.dkShares.path=/app/waspdb/dkshares"
-      - "--registries.trustedPeers.filePath=/app/waspdb/trusted_peers.json"
-      - "--registries.consensusState.path=/app/waspdb/chains/consensus"
-      - "--wal.path=/app/waspdb/wal"
       - "--prometheus.enabled=true"
       - "--prometheus.bindAddress=wasp:9312"
     profiles:
@@ -358,8 +343,8 @@ services:
       - "traefik.http.routers.wasp-dashboard.middlewares=rewrite-wasp-dashboard"
       - "traefik.http.middlewares.rewrite-wasp-dashboard.stripprefix.prefixes=/wasp/dashboard"
     environment:
-      - WASP_API_URL=http://localhost/wasp/api
-      - L1_API_URL=http://localhost
+      - WASP_API_URL=http://localhost:${HTTP_PORT:-80}/wasp/api
+      - L1_API_URL=http://localhost:${HTTP_PORT:-80}
     profiles:
       - wasp
 


### PR DESCRIPTION
⚠️ This PR is based on #1  ⚠️ 

# Description of change

- Fixed database paths, causing for example the Wasp dashboard to fail.
- Fixed URLs passed to the Wasp dashboard when using a different port through setting `HTTP_PORT` to something other than port 80.
- Added new line.

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Tested on WSL 2 with Ubuntu 22.04, by running `sudo ./bootstrap.sh` and `sudo docker compose --profile wasp up` from the `sandbox` directory.

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
