### PR TITLE
Use wasp RCs instead of alphas

### DIFF
--- a/sandbox/docker-compose.yml
+++ b/sandbox/docker-compose.yml
@@ -348,7 +348,7 @@ services:
 
   wasp:
     container_name: wasp
-    image: iotaledger/wasp:1.0-alpha
+    image: iotaledger/wasp:1.0-rc
     stop_grace_period: 5m
     restart: unless-stopped
     depends_on:
@@ -608,7 +608,7 @@ services:
 
   bootstrap-chain:
     container_name: bootstrap-chain
-    image: iotaledger/sandbox-wasp-cli:1.0-alpha
+    image: iotaledger/sandbox-wasp-cli:1.0-rc
     volumes:
       - ./data/sandboxdb/wasp-cli/config.json:/app/wasp-cli.json
     entrypoint: /app/wasp-cli
@@ -626,7 +626,7 @@ services:
 
   fund-chain-account:
     container_name: fund-chain-account
-    image: iotaledger/sandbox-wasp-cli:1.0-alpha
+    image: iotaledger/sandbox-wasp-cli:1.0-rc
     volumes:
       - ./data/sandboxdb/wasp-cli/config.json:/app/wasp-cli.json
     entrypoint: /app/wasp-cli


### PR DESCRIPTION
# Description of change

The latest release of the sandbox is broken, because the alphas now switched their wallet provider options and seed in that way is not supported anymore. So I switched to RCs which makes more sense anyway. We just had to stick with alphas as we needed the cli feature

## Type of change

- Bug fix (a non-breaking change which fixes an issue)

## How the change has been tested

Run locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code