### PR TITLE
Update to unsafe testing seed

### DIFF
--- a/sandbox/assets/wasp-cli/config.json
+++ b/sandbox/assets/wasp-cli/config.json
@@ -4,7 +4,8 @@
     "faucetaddress": "http://inx-faucet:8091"
   },
   "wallet": {
-    "seed": "0xf3bdf3ad8f401d1a2857d0eca48e440e600b6ff418db5cff80c5a7683c13215f17c992a74a2e5a2af9de651e2afba8e0c4ccfc817b51d452098cd388655d7d83"
+    "provider": "unsafe_inmemory_testing_seed",
+    "testing_seed": "0xf3bdf3ad8f401d1a2857d0eca48e440e600b6ff418db5cff80c5a7683c13215f17c992a74a2e5a2af9de651e2afba8e0c4ccfc817b51d452098cd388655d7d83"
   },
   "wasp": {
     "mr-glass": "http://wasp:9090"


### PR DESCRIPTION
# Description of change

As seed is no longer supported as a wasp-cli option, I switched to the new testing_save with the unsafe wallet provider. This should be merged once 1.0.3-rc got released

## Links to any relevant issues

Fixes #25.

## Type of change

- Enhancement (a non-breaking change which adds functionality)

## How the change has been tested

Run locally

## Change checklist

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
